### PR TITLE
added token sesion to user schema

### DIFF
--- a/src/features/User/schemas.ts
+++ b/src/features/User/schemas.ts
@@ -3,6 +3,7 @@ import {pgTable, varchar} from 'drizzle-orm/pg-core';
 export const user = pgTable('user', {
     username: varchar('username', { length: 255 }).primaryKey().notNull(),
     password: varchar('password', { length: 255 }).notNull(),
+    token: varchar('token')
 });
 
 export type User = typeof user.$inferSelect;


### PR DESCRIPTION
This pull request includes a small change to the `src/features/User/schemas.ts` file. The change adds a new `token` field to the `user` table schema.

* [`src/features/User/schemas.ts`](diffhunk://#diff-862e412ece542a8c3e6b8f1985691d29b3e9186b5e3f6f0371020bc47d072365R6): Added a `token` field to the `user` table schema.