### PR TITLE
added colors to user schema

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,3 +1,5 @@
 export const NotificationType: [string, ...string[]] = ['Information', 'Invitation']
 
 export const NotificationState: [string, ...string[]] = ['Unread', 'Read', 'Accepted']
+
+export const projectsColors: [string, ...string[]] = ['blue','gray','red','pink','purple','yellow','orange','cyan','green','emerald']

--- a/src/features/Project/schemas.ts
+++ b/src/features/Project/schemas.ts
@@ -1,11 +1,16 @@
 import {pgTable, varchar} from 'drizzle-orm/pg-core';
 import {uuid} from "drizzle-orm/pg-core/columns/uuid";
 import {user} from "../User/schemas";
+import {pgEnum} from "drizzle-orm/pg-core/columns/enum";
+import {projectsColors} from "../../enums";
+
+export const colors = pgEnum('colors',projectsColors)
 
 export const project = pgTable('project', {
     id: uuid('id').primaryKey().defaultRandom(),
     username: varchar('username').references(() => user.username, { onDelete: 'cascade', onUpdate: 'cascade' }).notNull(),
     name: varchar('name', { length: 255 }).notNull(),
+    color: colors('color').default(projectsColors[0]).notNull()
 });
 
 export type Project = typeof project.$inferSelect;

--- a/src/features/Project/utils.ts
+++ b/src/features/Project/utils.ts
@@ -6,17 +6,20 @@ export type ProjectQuery = {
     id?: string;
     username?: string;
     name?: string;
+    color?: string;
 };
 
 export type ProjectDto = {
     id: string;
     username: string;
     name: string;
+    color: string;
 };
 
 export const projectSchema = z.object({
     username: z.string(),
-    name: z.string()
+    name: z.string(),
+    color: z.string(),
 });
 
 export function ProjectQueryBuilder(query: ProjectQuery): SQL[] {
@@ -24,5 +27,6 @@ export function ProjectQueryBuilder(query: ProjectQuery): SQL[] {
     if (query.id) filters.push(eq(project.id, query.id));
     if (query.username) filters.push(eq(project.username, query.username));
     if (query.name) filters.push(eq(project.name, query.name));
+    if (query.color) filters.push(eq(project.color, query.color));
     return filters;
 }

--- a/src/relations/UsersToProjects/utils.ts
+++ b/src/relations/UsersToProjects/utils.ts
@@ -19,7 +19,8 @@ export const userToProjectsSelection = {
     project: {
         id: usersToProjects.project_id,
         username: project.username,
-        name: project.name
+        name: project.name,
+        color: project.color,
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to handle project colors across various parts of the codebase. The most important changes include adding a new enum for project colors, updating the project schema to include the color attribute, and modifying related utilities to support the new color attribute.

### Addition of project colors:

* [`src/enums.ts`](diffhunk://#diff-00310f3f832445de900d07b99183266cabc84aa21246ec7f1d136635b3108f79R4-R5): Introduced a new enum `projectsColors` containing a list of color options.

### Schema updates:

* [`src/features/Project/schemas.ts`](diffhunk://#diff-d5f9e10c8c2a7abbba66654f6e3f48cdfde10cf938a53689cb9a1fa2dbc719f2R4-R13): Added a new enum type `colors` using `pgEnum` and updated the `project` table schema to include a `color` attribute with a default value.

### Utility updates:

* [`src/features/Project/utils.ts`](diffhunk://#diff-0df98d6290ae35c281514d6460cfbda3db8979c1f7585c177fa7cbb012d0f6c4R9-R30): Updated `ProjectQuery`, `ProjectDto`, and `projectSchema` to include the `color` attribute. Also modified `ProjectQueryBuilder` to handle color-based filtering.
* [`src/relations/UsersToProjects/utils.ts`](diffhunk://#diff-a5a2f02b38d3319758f64f3b40eec6fcac18dada892a73eaadfda00396b0426fL22-R23): Updated the `userToProjectsSelection` to include the `color` attribute in the project selection.